### PR TITLE
[vizbuilder] Remove repeated items in SelectMultiHierarchy component using an unique level

### DIFF
--- a/app/components/SelectMultiHierarchy.jsx
+++ b/app/components/SelectMultiHierarchy.jsx
@@ -313,7 +313,7 @@ export function extendItems(items, levels, {getColor = () => "", getIcon = () =>
   });
 
   nestedItems.entries(items);
-  return extendedItems;
+  return Object.values(extendedItems.reduce((acc, cur) => Object.assign(acc, {[cur.id]: cur}), {}));
 }
 
 export default SelectMultiHierarchy;

--- a/app/pages/Vizbuilder/index.jsx
+++ b/app/pages/Vizbuilder/index.jsx
@@ -956,7 +956,6 @@ class Vizbuilder extends React.Component {
                 </div>
               </div>}
 
-
               {!isSubnat && productSelector && <div className="columns">
                 <div className="column-1">
                   <div className="selector select-multi-section-wrapper">
@@ -969,8 +968,7 @@ class Vizbuilder extends React.Component {
                         ? d => `/images/icons/sitc/sitc_${d["Category ID"]}.png`
                         : d => `/images/icons/hs/hs_${d["Section ID"]}.svg`}
                       items={this.state.product}
-                      // levels={["Section", "HS2", "HS4", "HS6"]}
-                      levels={this.state._dataset.productLevels}
+                      levels={chart === "rings" ? ["HS4"] : this.state._dataset.productLevels}
                       onItemSelect={item => this.safeChangeHandler("_selectedItemsProduct", item)}
                       onItemRemove={(evt, item) => {
                         // evt: MouseEvent<HTMLButtonElement>


### PR DESCRIPTION
This PR fixes the issue reported by @danaecatalan, only keeping valid HS4 products for Rings chart. I forced ["HS4"] level in the case of select Rings in `SelectMultiHierarchy`, and in the component itself, I filtered repeated items generated of my forcing of the list.