### PR TITLE
add covid page 

### DIFF
--- a/api/covid.js
+++ b/api/covid.js
@@ -1,0 +1,16 @@
+const axios = require("axios");
+
+const {OLAP_PROXY_ENDPOINT} = process.env;
+
+module.exports = function(app) {
+
+  app.get("/api/productsList", async(req, res) => {
+
+    const url = `${OLAP_PROXY_ENDPOINT}data?cube=trade_i_baci_a_92&drilldowns=HS6&measures=Trade+Value&parents=true&sparse=false`;
+    const data = await axios.get(url).then(res => res.data.data).catch(error => console.error("Covid Page Multihierarchy Selector Error:", error));
+
+    return res.json({
+      data
+    });
+  });
+};

--- a/app/helpers/covid.js
+++ b/app/helpers/covid.js
@@ -1,0 +1,304 @@
+import React  from "react";
+import {Spinner} from "@blueprintjs/core";
+import colors from "helpers/colors";
+
+export const currencySign = {
+  nacan: "C$",
+  aschn: "$",
+  eudeu: "€",
+  asjpn: "¥",
+  eurus: "$",
+  euesp: "€",
+  sabra: "$",
+  eugbr: "£",
+  nausa: "$",
+  afzaf: "ZAR",
+  askor: "$",
+  asmys: "$",
+  asphl: "$",
+  euswe: "SEK",
+  asind: "$"
+};
+
+export const monthNames = [
+  "January",
+  "February",
+  "March",
+  "April",
+  "May",
+  "June",
+  "July",
+  "August",
+  "September",
+  "October",
+  "November",
+  "December"
+];
+
+export const subnatCubeMembers = [
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#1AB558",
+    cube: "trade_s_bra_ncm_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "bra",
+    level: "Country",
+    parent_id: "sa",
+    parent: "South America",
+    product_category: "hs",
+    title: "Brazil",
+    value: "sabra"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#0068FF",
+    cube: "trade_s_can_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "can",
+    level: "Country",
+    parent_id: "na",
+    parent: "North America",
+    product_category: "hs",
+    title: "Canada",
+    value: "nacan"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#C8140A",
+    cube: "trade_s_chn_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "chn",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "hs",
+    title: "China",
+    value: "aschn"
+  },
+  {
+    avialablesDepth: ["EGW1", "Product"],
+    color: "#BA12CC",
+    cube: "trade_s_deu_m_egw",
+    depthDict: {},
+    label: "deu",
+    level: "Country",
+    parent_id: "eu",
+    parent: "Europe",
+    product_category: "egw",
+    title: "Germany",
+    value: "eudeu"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#C8140A",
+    cube: "trade_s_jpn_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "jpn",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "hs",
+    title: "Japan",
+    value: "asjpn"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#BA12CC",
+    cube: "trade_s_rus_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "rus",
+    level: "Country",
+    parent_id: "eu",
+    parent: "Europe",
+    product_category: "hs",
+    title: "Russia",
+    value: "eurus"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#FFDA00",
+    cube: "trade_s_zaf_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "zaf",
+    level: "Country",
+    parent_id: "af",
+    parent: "Africa",
+    product_category: "hs",
+    title: "South Africa",
+    value: "afzaf"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#BA12CC",
+    cube: "trade_s_esp_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "esp",
+    level: "Country",
+    parent_id: "eu",
+    parent: "Europe",
+    product_category: "hs",
+    title: "Spain",
+    value: "euesp"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#BA12CC",
+    cube: "trade_s_gbr_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "gbr",
+    level: "Country",
+    parent_id: "eu",
+    parent: "Europe",
+    product_category: "hs",
+    title: "United Kingdom",
+    value: "eugbr"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#0068FF",
+    cube: "trade_s_usa_state_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "usa",
+    level: "Country",
+    parent_id: "na",
+    parent: "North America",
+    product_category: "hs",
+    title: "United States",
+    value: "nausa"
+  },
+  {
+    avialablesDepth: ["Section", "HS2"],
+    color: "#C8140A",
+    cube: "trade_n_kor_m_hs",
+    depthDict: {},
+    label: "kor",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "hs",
+    title: "South Korea",
+    value: "askor"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#C8140A",
+    cube: "trade_n_mys_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "mys",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "hs",
+    title: "Malaysia",
+    value: "asmys"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#C8140A",
+    cube: "trade_n_phl_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "phl",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "hs",
+    title: "Philippines",
+    value: "asphl"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#BA12CC",
+    cube: "trade_n_swe_m_hs",
+    depthDict: {
+      HS6: "Product"
+    },
+    label: "swe",
+    level: "Country",
+    parent_id: "eu",
+    parent: "Europe",
+    product_category: "hs",
+    title: "Sweden",
+    value: "euswe"
+  },
+  {
+    avialablesDepth: ["Product"],
+    color: "#C8140A",
+    cube: "trade_s_ind_m_pc",
+    depthDict: {},
+    label: "ind",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "pc",
+    title: "India",
+    value: "asind"
+  }
+
+  /* COUNTRIES WITH NON UPDATED DATA
+  {
+    avialablesDepth: ["Section", "Division", "Group", "Product"],
+    color: "#1AB558",
+    cube: "trade_s_bol_m_sitc3",
+    label: "bol",
+    level: "Country",
+    parent_id: "sa",
+    parent: "South America",
+    product_category: "sitc3",
+    title: "Bolivia",
+    value: "sabol"
+  },
+  {
+    avialablesDepth: ["Section", "HS2", "HS4", "HS6"],
+    color: "#1AB558",
+    cube: "trade_s_ecu_m_hs",
+    label: "ecu",
+    level: "Country",
+    parent_id: "sa",
+    parent: "South America",
+    product_category: "hs",
+    title: "Ecuador",
+    value: "saecu"
+  },
+  {
+    avialablesDepth: ["Section", "HS2"],
+    color: "#C8140A",
+    cube: "trade_s_tur_m_hs",
+    label: "tur",
+    level: "Country",
+    parent_id: "as",
+    parent: "Asia",
+    product_category: "hs",
+    title: "Turkey",
+    value: "astur"
+  } */
+];
+
+export const productColor = d => colors.Section[d["Section ID"]];
+export const productIcon = d => `/images/icons/hs/hs_${d["Section ID"]}.svg`;
+export const productLevels = ["Section", "HS2", "HS4", "HS6"];
+
+export const spinner = <Spinner size={Spinner.SIZE_SMALL} />;
+
+

--- a/app/pages/Covid/Covid.css
+++ b/app/pages/Covid/Covid.css
@@ -23,7 +23,7 @@
     & .covid-column {
       flex: 1;
       padding: var(--gutter-sm);
-      & .aside {
+      .aside {
         max-width: 300px;
         min-width: 300px;
         transition: margin 0.7s ease 0s;

--- a/app/pages/Covid/Covid.css
+++ b/app/pages/Covid/Covid.css
@@ -1,0 +1,46 @@
+@import "../../helpers/mixins.css";
+
+.covid-profile {
+  background-color: var(--dark-4);
+  color: var(--white);
+  margin-top: var(--nav-height);
+
+  & .covid-content {
+    align-items: flex-start;
+    padding: 0.75rem 3rem;
+    width: 100%;
+  }
+
+  & .covid-title {
+    margin-top: var(--gutter-lg);
+    text-align: center;
+  }
+
+  & .covid-columns {
+    display: flex;
+    flex-wrap: wrap;
+    width: 100%;
+    & .covid-column {
+      flex: 1;
+      padding: var(--gutter-sm);
+      & .aside {
+        max-width: 300px;
+        min-width: 300px;
+        transition: margin 0.7s ease 0s;
+        & .controls {
+          width: 100%;
+          height: auto;
+          & label {
+            font-size: var(--font-lg);
+          }
+        }
+        & .oec-button-group-items {
+          margin-bottom: 0 !important;
+          & .cp-button {
+            flex: 1;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/pages/Covid/Covid.css
+++ b/app/pages/Covid/Covid.css
@@ -1,18 +1,19 @@
 @import "../../helpers/mixins.css";
 
 .covid-profile {
-  background-color: var(--dark-4);
+  background-color: var(--dark-3);
   color: var(--white);
   margin-top: var(--nav-height);
 
   & .covid-content {
+    background-color: var(--dark-3);
     align-items: flex-start;
-    padding: 0.75rem 3rem;
+    padding: 0.75rem 1.5rem;
     width: 100%;
   }
 
   & .covid-title {
-    margin-top: var(--gutter-lg);
+    margin-top: var(--gutter-sm);
     text-align: center;
   }
 
@@ -23,9 +24,9 @@
     & .covid-column {
       flex: 1;
       padding: var(--gutter-sm);
-      .aside {
-        max-width: 300px;
-        min-width: 300px;
+      &.aside {
+        max-width: 250px;
+        min-width: 250px;
         transition: margin 0.7s ease 0s;
         & .controls {
           width: 100%;
@@ -40,7 +41,83 @@
             flex: 1;
           }
         }
+
+        & .covid-selector {
+          flex-direction: column;
+          display: flex;
+          align-items: center;
+          justify-content: center;
+          margin-top: var(--gutter-sm);
+
+          & .covid-selector-config {
+            width: 100%;
+            align-items: center;
+            justify-content: left;
+            display: flex;
+            flex-wrap: wrap;
+
+            & .covid-selector-title {
+              font-family: "Montserrat", sans-serif;
+              font-size: 0.7rem;
+              margin-bottom: 5px;
+              margin-top: 10px;
+              text-transform: uppercase;
+            }
+
+            & .oec-button-group.cp-button-group {
+              width: 100%
+            }
+          }
+        }
+      }
+
+      & .covid-chart {
+        height: calc(100vh - var(--nav-height) - 8rem);
+        & .covid-chart-no-data {
+          align-items: center;
+          display: flex;
+          height: inherit;
+          justify-content: center;
+        }
+      }
+
+      & .covid-selector-title {
+        font-family: "Montserrat", sans-serif;
+        font-size: 0.7rem;
+        margin-bottom: 5px;
+        margin-top: 10px;
+        text-transform: uppercase;
+      }
+    }
+
+    & .covid-subtitle {
+      margin-top: var(--gutter-sm);
+      text-align: left;
+      text-transform: uppercase;
+    }
+  }
+}
+
+@media (max-width: 700px) {
+  .covid-profile {
+    & .covid-columns {
+      flex-direction: column;
+      & .covid-column.aside {
+        max-width: 100%;
+      }
+    }
+
+    & .covid-chart {
+      height: calc(100vh - var(--nav-height));
+    }
+
+    & .covid-chart-options {
+      flex-direction: row;
+      flex-wrap: wrap;
+      & .oec-button-group-title {
+        margin: 0;
       }
     }
   }
 }
+

--- a/app/pages/Covid/index.jsx
+++ b/app/pages/Covid/index.jsx
@@ -6,24 +6,52 @@ import {hot} from "react-hot-loader/root";
 import OECNavbar from "components/OECNavbar";
 import Footer from "components/Footer";
 
+import "./Covid.css";
+
 class Covid extends Component {
   constructor(props) {
     super(props);
-    this.state = {};
+    this.state = {
+      availableSubnatDatasets: [
+        "trade_s_bra_ncm_m_hs",
+        "trade_s_can_m_hs",
+        "trade_s_chn_m_hs",
+        "trade_s_deu_m_egw",
+        "trade_s_jpn_m_hs",
+        "trade_s_rus_m_hs",
+        "trade_s_zaf_m_hs",
+        "trade_s_esp_m_hs",
+        "trade_s_gbr_m_hs",
+        "trade_s_usa_state_m_hs"
+      ]
+    };
+  }
+
+  componentDidMount() {
+    const {availableSubnatDatasets} =
   }
 
   render() {
     return (
-      <div>
+      <div className="covid-profile">
         <OECNavbar />
-        <div>
-          <h1>COVID-19</h1>
+        <div className="covid-content">
+          <h1 className="covid-title">How has COVID affected international trade patterns?</h1>
+          <div className="covid-columns">
+            <div className="covid-column aside">
+              <p>Buttons</p>
+              <p>Buttons</p>
+            </div>
+            <div className="covid-column">
+              <p>Content</p>
+              <p>Content</p>
+            </div>
+          </div>
         </div>
         <Footer />
       </div>
     );
   }
-
 }
 
 export default hot(Covid);

--- a/app/pages/Covid/index.jsx
+++ b/app/pages/Covid/index.jsx
@@ -1,8 +1,10 @@
 import React, {Component} from "react";
 import {hot} from "react-hot-loader/root";
 //  import Helmet from "react-helmet";
-//  import axios from "axios";
+import axios from "axios";
+import {LinePlot} from "d3plus-react";
 
+import Loading from "components/Loading";
 import OECNavbar from "components/OECNavbar";
 import Footer from "components/Footer";
 
@@ -23,15 +25,46 @@ class Covid extends Component {
         "trade_s_esp_m_hs",
         "trade_s_gbr_m_hs",
         "trade_s_usa_state_m_hs"
-      ]
+      ],
+      data: [],
+      loading: true
     };
   }
 
   componentDidMount() {
-    const {availableSubnatDatasets} =
+    const {availableSubnatDatasets} = this.state;
+    const BASE = "/olap-proxy/data";
+
+    const promisesList = availableSubnatDatasets
+      .map(cube => `${BASE}?cube=${cube}&drilldowns=Time&measures=Trade+Value&Trade+Flow=2&parents=false&sparse=false`);
+
+    const allPromise = Promise.all(promisesList.map(url => axios.get(url))).then(responses => {
+      const finalResponse = [];
+
+      responses.map(res => {
+        res.data.data.forEach(item => item["Country ID"] = res.data.source[0].name);
+        finalResponse.push(res.data.data);
+      });
+
+      return finalResponse;
+    });
+
+    this.setState({
+      data: allPromise,
+      loading: false
+    });
   }
 
   render() {
+
+    const {data, loading} = this.state;
+
+    console.log(data);
+
+    if (loading) {
+      return <Loading />;
+    }
+
     return (
       <div className="covid-profile">
         <OECNavbar />
@@ -40,11 +73,27 @@ class Covid extends Component {
           <div className="covid-columns">
             <div className="covid-column aside">
               <p>Buttons</p>
-              <p>Buttons</p>
             </div>
             <div className="covid-column">
-              <p>Content</p>
-              <p>Content</p>
+              <LinePlot
+                config={{
+                  data: [
+                    {id: "alpha", x: 4, y: 9},
+                    {id: "alpha", x: 5, y: 17},
+                    {id: "alpha", x: 6, y: 13},
+                    {id: "beta",  x: 4, y: 17},
+                    {id: "beta",  x: 5, y: 8},
+                    {id: "beta",  x: 6, y: 16},
+                    {id: "gamma",  x: 4, y: 14},
+                    {id: "gamma",  x: 5, y: 9},
+                    {id: "gamma",  x: 6, y: 11}
+                  ],
+                  groupBy: "id",
+                  lineLabels: true,
+                  x: "x",
+                  y: "y"
+                }}
+              />
             </div>
           </div>
         </div>

--- a/app/pages/Covid/index.jsx
+++ b/app/pages/Covid/index.jsx
@@ -1,99 +1,315 @@
 import React, {Component} from "react";
-import {hot} from "react-hot-loader/root";
-//  import Helmet from "react-helmet";
+import {withNamespaces} from "react-i18next";
+import Helmet from "react-helmet";
 import axios from "axios";
 import {LinePlot} from "d3plus-react";
+import {formatAbbreviate} from "d3plus-format";
+
 
 import Loading from "components/Loading";
 import OECNavbar from "components/OECNavbar";
+import OECMultiSelect from "components/OECMultiSelect";
+import SelectMultiHierarchy from "components/SelectMultiHierarchy";
+import SimpleSelect from "components/SimpleSelect";
 import Footer from "components/Footer";
 
 import "./Covid.css";
+
+// Helpers
+import {currencySign, monthNames, productColor, productIcon, productLevels, spinner, subnatCubeMembers} from "helpers/covid";
+
+const BASE = "/olap-proxy/data";
 
 class Covid extends Component {
   constructor(props) {
     super(props);
     this.state = {
-      availableSubnatDatasets: [
-        "trade_s_bra_ncm_m_hs",
-        "trade_s_can_m_hs",
-        "trade_s_chn_m_hs",
-        "trade_s_deu_m_egw",
-        "trade_s_jpn_m_hs",
-        "trade_s_rus_m_hs",
-        "trade_s_zaf_m_hs",
-        "trade_s_esp_m_hs",
-        "trade_s_gbr_m_hs",
-        "trade_s_usa_state_m_hs"
-      ],
+      availableDates: [],
+      countryMembers: subnatCubeMembers,
       data: [],
-      loading: true
+      flow: "Exports",
+      flowId: 2,
+      loading: true,
+      _selectedItemsCountry: subnatCubeMembers,
+      _selectedFlow: {
+        value: 2,
+        title: "Exports"
+      },
+      _startDate: {
+        value: 201905,
+        title: "May 2019"
+      },
+      productCuts: [],
+      productOptions: []
     };
   }
 
   componentDidMount() {
-    const {availableSubnatDatasets} = this.state;
-    const BASE = "/olap-proxy/data";
+    const {countryMembers, flowId, _startDate, productCuts} = this.state;
+    this.fetchData(countryMembers, flowId, _startDate.value, productCuts);
+  }
 
-    const promisesList = availableSubnatDatasets
-      .map(cube => `${BASE}?cube=${cube}&drilldowns=Time&measures=Trade+Value&Trade+Flow=2&parents=false&sparse=false`);
+  createDates = date => {
+    const monthId = date.toString().slice(-2) * 1 - 1;
+    const month = monthNames[monthId];
+    const year = date.toString().slice(0, 4) * 1;
 
-    const allPromise = Promise.all(promisesList.map(url => axios.get(url))).then(responses => {
-      const finalResponse = [];
+    const formattedDate = {
+      value: date,
+      title: `${month} ${year}`
+    };
 
-      responses.map(res => {
-        res.data.data.forEach(item => item["Country ID"] = res.data.source[0].name);
-        finalResponse.push(res.data.data);
+    return formattedDate;
+  }
+
+  fetchData = (urls, flowId, dateId, productCuts) => {
+    let {availableDates, productOptions} = this.state;
+    let _productCut = [];
+
+    if (productCuts && productCuts.length > 0) {
+      urls = urls.filter(d => d.product_category === "hs" && d.avialablesDepth.includes(productCuts[0].type));
+      _productCut = urls.map(d => `&${d.depthDict[productCuts[0].type] || productCuts[0].type}=${productCuts[0].id}`);
+    }
+
+    const promisesList = urls
+      .map((url, i) => _productCut.length > 0
+        ? `${BASE}?cube=${url.cube}&drilldowns=Time&measures=Trade+Value&Trade+Flow=${flowId}&parents=true&sparse=false${_productCut[i]}`
+        : `${BASE}?cube=${url.cube}&drilldowns=Time&measures=Trade+Value&Trade+Flow=${flowId}&parents=true&sparse=false`);
+
+    if (this.state.loading) {
+      promisesList.push("/api/productsList");
+    }
+
+    const allPromises = [];
+
+    Promise.all(promisesList.map(url => axios.get(url))).then(responses => {
+      responses.map((res, i) => {
+        let _data = res.data.data;
+
+        if (i === responses.length - 1 && this.state.loading) {
+          productOptions = _data;
+        }
+        else {
+
+          _data = _data.filter(d => d.Time >= 201801);
+
+          if (this.state.loading) {
+            _data.map(d => availableDates ? !availableDates.find(h => h.value === d.Time) ? availableDates.push(this.createDates(d.Time)) : false : false);
+          }
+
+          _data.forEach(d => {
+            d["Previous Year"] = d.Year - 1;
+            d["Continent ID"] = urls[i].parent_id;
+            d.Continent = urls[i].parent;
+            d["Country ID"] = urls[i].value;
+            d.Country = urls[i].title;
+            d.Date = `${d.Time.toString().slice(-2)}/01/${d.Time.toString().slice(0, 4)}`;
+            d["Trade Value Previous"] = _data.find(h => h.Time === dateId) ? _data.find(h => h.Time === dateId)["Trade Value"] : 0;
+          });
+
+          _data.forEach(d => {
+            d["Trade Value Growth"] = this.growth(d["Trade Value Previous"], d["Trade Value"]);
+            d["Trade Value Growth Value"] = d["Trade Value"] - d["Trade Value Previous"];
+          });
+
+          allPromises.push(_data.filter(d => d.Time >= dateId && isFinite(d["Trade Value Growth"])));
+        }
       });
 
-      return finalResponse;
-    });
+      if (this.state.loading) {
+        availableDates = availableDates.slice(0, -1);
+      }
 
-    this.setState({
-      data: allPromise,
-      loading: false
+      this.setState({
+        availableDates,
+        data: allPromises.flat(),
+        loading: false,
+        productOptions
+      });
     });
   }
 
-  render() {
+  growth(prev, curr) {
+    const value = (curr - prev) / prev;
+    return value * 100;
+  }
 
-    const {data, loading} = this.state;
+  handleItemMultiSelect = (key, d) => {
+    const {_selectedItemsCountry, _startDate, countryMembers, flowId, productCuts} = this.state;
 
-    console.log(data);
+    this.setState({[key]: Array.isArray(d) ? d : new Array(d)});
 
-    if (loading) {
-      return <Loading />;
+    if (key === "_selectedItemsCountry") {
+      this.fetchData(d.map(item => item), flowId, _startDate.value, productCuts);
     }
+    else {
+      this.fetchData(_selectedItemsCountry.length > 0 ? _selectedItemsCountry : countryMembers, flowId, _startDate.value, new Array(d));
+
+      if (_selectedItemsCountry.length === 0) {
+        this.setState({
+          _selectedItemsCountry: countryMembers
+        });
+      }
+    }
+  };
+
+  removeItemMultiSelect = (key, value) => {
+    const {_selectedItemsCountry, countryMembers, _startDate, flowId, productCuts} = this.state;
+
+    if (key === "_selectedItemsCountry") {
+      this.fetchData(countryMembers, flowId, _startDate.value, productCuts);
+    }
+    else {
+      this.fetchData(_selectedItemsCountry, flowId, _startDate.value, []);
+    }
+
+    this.setState({
+      [key]: value
+    });
+  }
+
+  removeSelectedItem = () => {
+    const {_selectedItemsCountry, _startDate, flowId} = this.state;
+    let {productCuts} = this.state;
+
+    productCuts = [];
+
+    this.fetchData(_selectedItemsCountry, flowId, _startDate.value, productCuts);
+
+    this.setState({
+      productCuts
+    });
+  }
+
+  updateFilter = (key, value) => {
+    const {_selectedItemsCountry, flowId, productCuts} = this.state;
+
+    this.fetchData(_selectedItemsCountry, flowId, value.value, productCuts);
+
+    this.setState({
+      [key]: value
+    });
+  };
+
+  render() {
+    const {_selectedFlow, _selectedItemsCountry, _startDate, availableDates, countryMembers, data, flow, loading, productCuts, productOptions} = this.state;
 
     return (
       <div className="covid-profile">
         <OECNavbar />
+        <Helmet title="Latest Trends Explorer" />
         <div className="covid-content">
-          <h1 className="covid-title">How has COVID affected international trade patterns?</h1>
           <div className="covid-columns">
             <div className="covid-column aside">
-              <p>Buttons</p>
+              <div className="content">
+                <div className="columns">
+                  <h3 className="covid-subtitle">Lastest Trends Explorer</h3>
+                  <div className="column-1 ">
+                    <SimpleSelect
+                      items={[
+                        {
+                          value: 2,
+                          title: "Exports"
+                        },
+                        {
+                          value: 1,
+                          title: "Imports"
+                        }
+                      ]}
+                      state="flowId"
+                      selectedItem={_selectedFlow}
+                      title={"Flow"}
+                      callback={value => {
+                        this.fetchData(_selectedItemsCountry, value.value, _startDate.value);
+                        this.setState({
+                          _selectedFlow: value,
+                          flow: value.title,
+                          flowId: value.value
+                        });
+                      }}
+                    />
+                    <SimpleSelect
+                      items={availableDates}
+                      title={"Reference Period"}
+                      state="_startDate"
+                      selectedItem={_startDate}
+                      callback={this.updateFilter}
+                    />
+                  </div>
+                  <div className="column-1">
+                    <OECMultiSelect
+                      items={countryMembers}
+                      itemType={"country"}
+                      selectedItems={_selectedItemsCountry}
+                      placeholder={"Select a country..."}
+                      title={"Country"}
+                      onClear={() => {
+                        this.removeItemMultiSelect("_selectedItemsCountry", []);
+                      }}
+                      callback={d => this.handleItemMultiSelect("_selectedItemsCountry", d)}
+                    />
+                  </div>
+                  <div className="column-1">
+                    <h3 className="covid-selector-title">Product</h3>
+                    <SelectMultiHierarchy
+                      getColor={productColor}
+                      getIcon={productIcon}
+                      inputRightIcon={loading && spinner}
+                      items={productOptions}
+                      levels={productLevels}
+                      placeholder={"Select a product..."}
+                      selectedItems={productCuts}
+                      onClear={() => {
+                        this.removeItemMultiSelect("productCuts", []);
+                      }}
+                      onItemSelect={d => this.handleItemMultiSelect("productCuts", d)}
+                      onItemRemove={item => {
+                        this.removeSelectedItem("productCuts", item);
+                      }}
+                    />
+                  </div>
+                </div>
+              </div>
             </div>
             <div className="covid-column">
-              <LinePlot
-                config={{
-                  data: [
-                    {id: "alpha", x: 4, y: 9},
-                    {id: "alpha", x: 5, y: 17},
-                    {id: "alpha", x: 6, y: 13},
-                    {id: "beta",  x: 4, y: 17},
-                    {id: "beta",  x: 5, y: 8},
-                    {id: "beta",  x: 6, y: 16},
-                    {id: "gamma",  x: 4, y: 14},
-                    {id: "gamma",  x: 5, y: 9},
-                    {id: "gamma",  x: 6, y: 11}
-                  ],
-                  groupBy: "id",
-                  lineLabels: true,
-                  x: "x",
-                  y: "y"
-                }}
-              />
+              <h1 className="covid-title">How has COVID affected international trade patterns?</h1>
+              {loading &&
+              <div className="covid-chart">
+                <Loading />
+              </div>}
+              {!loading &&
+              <div className="covid-chart">
+                <LinePlot
+                  config={{
+                    data,
+                    discrete: "x",
+                    groupBy: ["Continent ID", "Country"],
+                    heigth: 400,
+                    legendTooltip: {
+                      tbody: []
+                    },
+                    lineLabels: true,
+                    time: "Date",
+                    timeline: false,
+                    tooltipConfig: {
+                      tbody: [
+                        ["Period", d => `${d.Month} ${d.Year}`],
+                        ["Reference Period", () => _startDate.title],
+                        [`Relative ${flow} Growth`, d => `${currencySign[d["Country ID"]]} ${formatAbbreviate(d["Trade Value Growth Value"])}`],
+                        [`Relative ${flow} Growth (%)`, d => `${formatAbbreviate(d["Trade Value Growth"])}%`]
+                      ]
+                    },
+                    total: false,
+                    x: "Date",
+                    y: "Trade Value Growth",
+                    yConfig: {
+                      scale: "linear",
+                      tickFormat: d => `${d}%`
+                    }
+                  }}
+                />
+              </div>
+              }
             </div>
           </div>
         </div>
@@ -103,4 +319,4 @@ class Covid extends Component {
   }
 }
 
-export default hot(Covid);
+export default withNamespaces()(Covid);

--- a/app/pages/Covid/index.jsx
+++ b/app/pages/Covid/index.jsx
@@ -1,0 +1,29 @@
+import React, {Component} from "react";
+import {hot} from "react-hot-loader/root";
+//  import Helmet from "react-helmet";
+//  import axios from "axios";
+
+import OECNavbar from "components/OECNavbar";
+import Footer from "components/Footer";
+
+class Covid extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {};
+  }
+
+  render() {
+    return (
+      <div>
+        <OECNavbar />
+        <div>
+          <h1>COVID-19</h1>
+        </div>
+        <Footer />
+      </div>
+    );
+  }
+
+}
+
+export default hot(Covid);

--- a/app/routes.jsx
+++ b/app/routes.jsx
@@ -23,6 +23,7 @@ import Rankings from "./pages/Rankings";
 import Resources from "./pages/Resources";
 import Loading from "components/Loading";
 import ErrorPage from "./pages/ErrorPage";
+import Covid from "./pages/Covid";
 
 import {HS_TO_OEC_HS} from "helpers/consts";
 
@@ -120,6 +121,7 @@ export default function RouteCreate() {
       <Route exact path="/:lang/signup" component={SignUp} />
       <Route exact path="/:lang/reset" component={Reset} />
       <Route exact path="/:lang/account" component={Account} />
+      <Route exact path="/:lang/covid" component={Covid} />
       {/* <Route exact path="/:lang/subscription" component={Subscription} /> */}
       <Route exact path="/:lang/subnational" component={Subnational} />
       <Route exact path="/:lang/prediction" component={PredictionLanding} />


### PR DESCRIPTION
This PR adds a COVID page to OEC (`/en/covid)`.

Using subnational cubes, the COVID page allows to explore trade patterns with latest data reported by the custom services of each available country (except Chile, Ecuador, Bolivia and Turkey).